### PR TITLE
Add workaround for unit tests for change of behaviour in mock call args in Python version < 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,4 @@ fallback_version = "0.0.0"
 [tool.pytest.ini_options]
 addopts = "-p no:fluent-logging -p pytester"
 log_level = "INFO"
+pythonpath = ["src"]

--- a/tests/mock_args_workaround.py
+++ b/tests/mock_args_workaround.py
@@ -1,0 +1,13 @@
+import sys
+
+
+def get_call_arg_args(call_arg):
+    if sys.version_info[1] >= 8:
+        args = call_arg.args
+    else:
+        args = call_arg[0]
+    return args
+
+
+def get_call_arg_data(call_arg):
+    return get_call_arg_args(call_arg)[2]

--- a/tests/test_additional_information.py
+++ b/tests/test_additional_information.py
@@ -3,6 +3,9 @@ from pytest_fluent import (
     additional_test_information_callback,
 )
 
+from .mock_args_workaround import get_call_arg_data
+
+
 
 @additional_session_information_callback
 def session_info() -> dict:
@@ -20,7 +23,7 @@ def test_additional_information(run_mocked_pytest, session_uuid):
     fluent_sender = sender.return_value
     call_args = fluent_sender.emit_with_time.call_args_list
     for idx, call_arg in enumerate(call_args):
-        data = call_arg.args[2]
+        data = get_call_arg_data(call_arg)
         if idx == 0:
             assert data.get("type") == "myCustomSession"
         if idx == 1:

--- a/tests/test_addoptions.py
+++ b/tests/test_addoptions.py
@@ -2,6 +2,9 @@ import uuid
 
 from fluent.sender import EventTime
 
+from .mock_args_workaround import get_call_arg_args, get_call_arg_data
+
+
 tag = "unittest"
 label = "pytest"
 
@@ -21,14 +24,14 @@ def test_fluentd_logged_parameters(
     result.assert_outcomes(passed=1)
     assert len(call_args) > 0
     for idx, call_arg in enumerate(call_args):
-        args = call_arg.args
+        args = get_call_arg_args(call_arg)
         if idx not in [2, 3]:
             assert args[0] == label
             assert isinstance(args[1], int)
         else:
             assert args[0] is None
             assert isinstance(args[1], EventTime)
-        data = args[2]
+        data = get_call_arg_data(call_arg)
         assert isinstance(data, dict)
         if idx in [0, 1]:
             assert data.get("status") == "start"

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,3 +1,5 @@
+from .mock_args_workaround import get_call_arg_data
+
 def test_get_logger(run_mocked_pytest, session_uuid, logging_content):
     runpytest, sender = run_mocked_pytest
     result = runpytest(
@@ -15,7 +17,7 @@ def test_get_logger(run_mocked_pytest, session_uuid, logging_content):
     result.assert_outcomes(passed=1)
     assert len(call_args) > 0
     for idx, call_arg in enumerate(call_args):
-        data = call_arg.args[2]
+        data = get_call_arg_data(call_arg)
         if idx in [2, 3]:
             assert data.get("type") == "logging"
             assert "host" in data

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,3 +1,6 @@
+from .mock_args_workaround import get_call_arg_data
+
+
 def test_data_reporter_base_with_passed(run_mocked_pytest, session_uuid):
     runpytest, sender = run_mocked_pytest
     result = runpytest(
@@ -11,7 +14,7 @@ def test_data_reporter_base_with_passed(run_mocked_pytest, session_uuid):
     call_args = fluent_sender.emit_with_time.call_args_list
     result.assert_outcomes(passed=1)
     assert len(call_args) > 0
-    report = call_args[2].args[2]
+    report = get_call_arg_data(call_args[2])
     assert (
         report.get("name")
         == "test_data_reporter_base_with_passed.py::test_base"
@@ -93,7 +96,7 @@ def test_data_reporter_base_with_xfail(run_mocked_pytest, session_uuid):
     fluent_sender = sender.return_value
     call_args = fluent_sender.emit_with_time.call_args_list
     assert len(call_args) > 0
-    args = call_args[2].args[2]
+    args = get_call_arg_data(call_args[2])
     assert args.get("outcome") == "xfailed"
     assert "failure_message" in args
     assert args.get("markers", {}).get("xfail") == 1
@@ -112,7 +115,7 @@ def test_data_reporter_base_with_exception(run_mocked_pytest, session_uuid):
     fluent_sender = sender.return_value
     call_args = fluent_sender.emit_with_time.call_args_list
     assert len(call_args) > 0
-    args = call_args[2].args[2]
+    args = get_call_arg_data(call_args[2])
     assert args.get("when") == "call"
     assert args.get("outcome") == "error"
     assert "failure_message" in args
@@ -141,7 +144,7 @@ def test_data_reporter_base_with_setup_exception(
     fluent_sender = sender.return_value
     call_args = fluent_sender.emit_with_time.call_args_list
     assert len(call_args) > 0
-    args = call_args[2].args[2]
+    args = get_call_arg_data(call_args[2])
     assert args.get("when") == "setup"
     assert args.get("outcome") == "error"
     assert "failure_message" in args

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ isolated_build = True
 install_command = pip install -i {env:PIP_INDEX_URL:https://pypi.org/simple} {opts} {packages}
 extras = test
 commands =
-    test-py3{5,6,7,8,9,10}: pytest {posargs:tests}
+    test-py3{7,8,9,10,11}: pytest {posargs:tests}
 
 [testenv:format]
 description = Autoformat code.


### PR DESCRIPTION
This PR includes a fix for #13 and #12.

What I discovered is that the behaviour in the unittest mock changed between Python versions 3.7 and 3.8. While the test code is correct for Python 3.8 and above, they failed for Python 3.7. More information on what changed is here:

https://bugs.python.org/issue21269

For more context, here is an SO post where someone came across the same problem:

https://stackoverflow.com/questions/60105443/how-do-i-correctly-use-mock-call-args-with-pythons-unittest-mock

I also updated tox.ini to drop Python 3.6 (#12) and to include support for Python 3.11.