### PR TITLE
Log session duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ pytest-fluent sends any information, e.g. stage information or logging from a te
     },
     {
         "status": "finish",
+        "duration": 0.00297708511352539,
         "stage": "session",
         "sessionId": "d8f01de3-8416-4801-9406-0ea3d5cfe3c0"
     }

--- a/src/pytest_fluent/plugin.py
+++ b/src/pytest_fluent/plugin.py
@@ -6,6 +6,7 @@ from io import BytesIO
 
 import msgpack
 import pytest
+import time
 from fluent import event, sender
 from fluent.handler import FluentHandler, FluentRecordFormatter
 
@@ -23,6 +24,7 @@ from .test_report import LogReport
 class FluentLoggerRuntime(object):
     def __init__(self, config):
         self._session_uuid = None
+        self._session_start_time = None
         self._test_uuid = None
         self.config = config
         self._set_session_uid(self.config.getoption("--session-uuid"))
@@ -82,6 +84,7 @@ class FluentLoggerRuntime(object):
     def pytest_sessionstart(self):
         """Custom hook for session start."""
         set_stage("session")
+        self._session_start_time = time.time()
         if not self.config.getoption("collectonly"):
             data = {
                 "status": "start",
@@ -168,6 +171,7 @@ class FluentLoggerRuntime(object):
                 self._label,
                 {
                     "status": "finish",
+                    "duration": time.time() - self._session_start_time,
                     "stage": "session",
                     "sessionId": self.session_uid,
                 },

--- a/tests/test_addoptions.py
+++ b/tests/test_addoptions.py
@@ -44,6 +44,8 @@ def test_fluentd_logged_parameters(
             assert data.get("message") == logging_content
         if idx in [0, 6]:
             assert data.get("stage") == "session"
+        if idx == 6:
+            assert data.get("duration") > 0
         if idx in [1, 2, 3, 4, 5]:
             assert data.get("stage") == "testcase"
             assert "testId" in data


### PR DESCRIPTION
This MR adds a session duration field to the session finish message.

Example:

```json
    {
        "status": "finish",
        "duration": 0.00297708511352539,
        "stage": "session",
        "sessionId": "d8f01de3-8416-4801-9406-0ea3d5cfe3c0"
    }
```