### PR TITLE
Add ability to send test docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The pytest CLI can be called with the following arguments in order to configure 
 | --fluentd-tag    | Set a custom Fluentd tag                                                          | 'test'   |
 | --fluentd-label  | Set a custom Fluentd label                                                        | 'pytest' |
 | --extend-logging | Extend the Python logging with a Fluent handler                                   | False    |
+| --add-docstrings | Add test docstrings to testcase call messages                                     |          |
 
 ### Ini Configuration Support 
 

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,0 +1,61 @@
+TEST_DOCSTRING = "This test will always pass."
+
+
+def test_add_docstrings(run_mocked_pytest, session_uuid):
+    runpytest, sender = run_mocked_pytest
+    result = runpytest(
+        f"--session-uuid={session_uuid}",
+        "--add-docstrings",
+        pyfile=f"""
+    def test_base():
+        '''
+        {TEST_DOCSTRING}
+        '''
+        assert True
+    """,
+    )
+    fluent_sender = sender.return_value
+    call_args = fluent_sender.emit_with_time.call_args_list
+    result.assert_outcomes(passed=1)
+    assert len(call_args) > 0
+    report = call_args[2].args[2]
+    assert "docstring" in report
+    assert report.get("docstring") == TEST_DOCSTRING
+
+
+def test_docstrings_disabled(run_mocked_pytest, session_uuid):
+    runpytest, sender = run_mocked_pytest
+    result = runpytest(
+        f"--session-uuid={session_uuid}",
+        pyfile=f"""
+    def test_base():
+        '''
+        {TEST_DOCSTRING}
+        '''
+        assert True
+    """,
+    )
+    fluent_sender = sender.return_value
+    call_args = fluent_sender.emit_with_time.call_args_list
+    result.assert_outcomes(passed=1)
+    assert len(call_args) > 0
+    report = call_args[2].args[2]
+    assert "docstring" not in report
+
+
+def test_missing_docstring(run_mocked_pytest, session_uuid):
+    runpytest, sender = run_mocked_pytest
+    result = runpytest(
+        f"--session-uuid={session_uuid}",
+        "--add-docstrings",
+        pyfile="""
+    def test_base():
+        assert True
+    """,
+    )
+    fluent_sender = sender.return_value
+    call_args = fluent_sender.emit_with_time.call_args_list
+    result.assert_outcomes(passed=1)
+    assert len(call_args) > 0
+    report = call_args[2].args[2]
+    assert "docstring" not in report


### PR DESCRIPTION
This MR adds the ability to send test docstrings as part of the testcase call messages.

Docstrings are only included if the option `--add-docstrings` is set.