### PR TITLE
Minor formatting changes to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ def test_my_runtime_log():
 
 ### Fixtures
 
-In order to create your own logger, set up a fixture as follows:
+In order to create your own logger, request a fixture as follows:
 
 ```python
 def test_my_runtime_log(get_logger):

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 [![Documentation](https://readthedocs.org/projects/pytest-fluent/badge/?version=latest)](https://pytest-fluent.readthedocs.io/) [![Build Status](https://github.com/Rohde-Schwarz/pytest-fluent/actions/workflows/tests.yml/badge.svg)](https://github.com/Rohde-Schwarz/pytest-fluent/actions/) [![PyPI Versions](https://img.shields.io/pypi/pyversions/pytest-fluent.svg)](https://pypi.python.org/pypi/pytest-fluent) ![PyPI - Downloads](https://img.shields.io/pypi/dm/pytest-fluent)  [![PyPI Status](https://img.shields.io/pypi/status/pytest-fluent.svg)](https://pypi.python.org/pypi/pytest-fluent) [![PyPI License](https://img.shields.io/badge/License-MIT-green)](LICENSE)
 
-A Python package in order to extend pytest by fluentd logging
+_pytest-fluent_ is a Python package in order to extend _pytest_ using _Fluentd_ for logging test results.
 
 ## Description
 
-Pytest is one of the most powerful testing suites with a lot of functionality and many plugins. Fluentd is a well-established log collector which is used in many modern web architectures. So, why not putting both worlds together in order to gain real-time log access to your distributed test runs.
+_pytest_ is one of the most powerful testing suites with a lot of functionality and many plugins. _Fluentd_ is a well-established log collector which is used in many modern web architectures. So, why not putting both worlds together in order to gain real-time log access to your distributed test runs?
 
-pytest-fluent enables you to forward your test data immediately to your prefered log-sink from any node spread around your infrastructure. The streamed data are available for each pytest stage and formatted in JSON.
+_pytest-fluent_ enables you to forward your test data immediately to your preferred log-sink from any node spread around your infrastructure. The streamed data are available for each pytest stage and formatted in JSON.
 
-Each pytest session gets an unique identifier (UID) assigned as well as each executed test case. With these UIDs, you can filter easily for sessions and testcase data entries, for instance in your favorite database.
+Each _pytest_ session gets an unique identifier (UID) assigned as well as each executed test case. With these UIDs, you can easily filter sessions and testcase data entries, for instance in your favorite database.
 
 ## Installation
 
-The package is available at pypi.org and can be installed by typing
+The package is available at [pypi.org](https://pypi.org/project/pytest-fluent/) and can be installed by typing
 
 ```shell
 pip install pytest-fluent
@@ -22,7 +22,7 @@ pip install pytest-fluent
 
 ## Usage
 
-pytest-fluent-logging forwards meta data from pytest to Fluentd for further processing. The meta data are
+_pytest-fluent-logging_ forwards meta data from _pytest_ to _Fluentd_ for further processing. The meta data are
 
 * unique session ID
 * unique test ID
@@ -32,8 +32,9 @@ pytest-fluent-logging forwards meta data from pytest to Fluentd for further proc
 * `record_property` entries
 * custom testcase information
 * custom session information
+* timestamps
 
-Furthermore, the Python logging instance can be extended in order to forward test case runtime logging.
+Furthermore, the Python logging instance can be extended in order to forward test case runtime logging:
 
 ```python
 from logging import getLogger
@@ -44,7 +45,7 @@ def test_my_runtime_log():
     assert value == 1
 ```
 
-or
+or:
 
 ```python
 from logging import getLogger
@@ -57,7 +58,7 @@ def test_my_runtime_log():
 
 ### Fixtures
 
-In order to create your own logger, request the following fixture
+In order to create your own logger, set up a fixture as follows:
 
 ```python
 def test_my_runtime_log(get_logger):
@@ -67,10 +68,10 @@ def test_my_runtime_log(get_logger):
     assert value == 1
 ```
 
-If you want to get the current UIDs, use the following fixtures
+If you want to get the current UIDs, use the `session_uid` and `test_uid` fixtures as follows:
 
 ```python
-def test_unique_identifier(session_uid, test_uid):
+def test_unique_identifier(get_logger, session_uid, test_uid):
     logger = get_logger('fluent')
     logger.info(f"Session ID: {session_uid}")
     logger.info(f"Test ID: {test_uid}")
@@ -80,7 +81,7 @@ def test_unique_identifier(session_uid, test_uid):
 
 ### Callbacks
 
-If you want to add custom data to the datasets of the `pytest_sessionstart` and `pytest_runtest_logstart` stages, decorate your callback functions with the following decorators.
+If you want to add custom data to the datasets of the `pytest_sessionstart` and `pytest_runtest_logstart` stages, decorate your callback functions with the following decorators:
 
 ```python
 from pytest_fluent import (
@@ -101,9 +102,9 @@ def provide_more_test_information() -> dict:
     }
 ```
 
-### pytest CLI extensions
+### _pytest_ CLI extensions
 
-The pytest CLI can be called with the following arguments in order to configure fluent-logging.
+The _pytest_ CLI application can be called with the following arguments in order to configure _fluent-logging_.
 
 | argument            | description                                                                                                                          | default  |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------- |
@@ -121,32 +122,32 @@ The pytest CLI can be called with the following arguments in order to configure 
 
 Default values of the CLI arguments for a project could also be defined in one of the following ini configuration files:
 
-1. pytest.ini: Arguments are defined under pytest section in the file. This file takes precedence over all other configuration files even if empty.
+1. `pytest.ini`: Arguments are defined under the `pytest` section in the file. This file takes precedence over all other configuration files even if it's empty.
 
 ```python
 [pytest]
 addopts= --session-uuid="ac2f7600-a079-46cf-a7e0-6408b166364c" --fluentd-port=24224  --fluentd-host=localhost --fluentd-tag='dummytest' --fluentd-label='pytest' --extend-logging
 ```
 
-2. pyproject.toml: are considered for configuration when they contain a tool.pytest.ini_options section is available
+2. `pyproject.toml`: are considered for configuration when they contain a `tool.pytest.ini_options` section is available
 
 ```python
 [tool.pytest.ini_options]
 addopts="--fluentd-port=24224 --fluentd-host=localhost --fluentd-tag='test' --fluentd-label='pytest' --extend-logging"
 ```
 
-3. tox.ini: can also be used to hold pytest configuration if they have a [pytest] section.
+3. `tox.ini`: can also be used to hold pytest configuration if they have a [pytest] section.
 
 ```python
 [pytest]
 addopts= --fluentd-port=24224 --fluentd-host=localhost --fluentd-tag='test' --fluentd-label='pytest'
 ```
 
-If the same option is specified in both CLI and ini file, then CLI option would have higher priority and override the ini file values.
+If the same option is specified in both CLI and _ini_ file, then CLI option would have higher priority and override the _ini_ file values.
 
 ### What data are sent?
 
-pytest-fluent sends any information, e.g. stage information or logging from a test case, as a single chunk. For instance, the data collection from `test_addoptions.py` test looks as following
+_pytest-fluent_ sends any information, e.g. stage information or logging from a test case, as a single chunk. For instance, the data collection from `test_addoptions.py` test looks as following
 
 ```json
 [
@@ -214,7 +215,7 @@ pytest-fluent sends any information, e.g. stage information or logging from a te
 ]
 ```
 
-whereat each object in the array is sent independently via Fluentd.
+whereat each object in the array is sent independently via _Fluentd_.
 
 ### Specifying a timestamp
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ def test_my_runtime_log():
 
 ### Fixtures
 
-In order to create your own logger, request a fixture as follows:
+In order to create your own logger, request the fixture `get_logger` as follows:
 
 ```python
 def test_my_runtime_log(get_logger):

--- a/docs/usage/stage_settings.md
+++ b/docs/usage/stage_settings.md
@@ -1,9 +1,9 @@
 ### Custom stage settings
 
-Sometimes, the default settings are not enough in order to forward the test information as needed. Thus, you can set custom stage settings
+Sometimes, the default settings are not enough in order to forward the test information as needed. Therefore, you can set custom stage settings
 in order to fit your needs.
 
-You can set specific values for `all` stages or specific values for any used stage. In order to do so, call your test run with the `--stage-settings=YourFileName.json` parameter. The following example stage settings JSON file content
+You can set specific values for `all` stages or specific values for any used stage. In order to do so, call your test run with the `--stage-settings=YourFileName.json` parameter. The following example stage settings JSON file content:
 
 ```json
 {
@@ -41,7 +41,7 @@ You can set specific values for `all` stages or specific values for any used sta
 }
 ```
 
-will result in the following output
+will result in the following output:
 
 ```json
 [
@@ -109,7 +109,7 @@ will result in the following output
 ]
 ```
 
-for this test case
+for this test case:
 
 ```python
 import logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Framework :: Pytest"
 ]
 requires-python = ">=3.8"


### PR DESCRIPTION
Made changes to README.md, including:

- Some minor formatting
- Some minor typos

I want to note right now that the badges are not updated, and they display some out-of-date information, especially the range of Python versions that are supported. pyproject.toml now indicates that we only support Python >= 3.8 and including 3.11, but this is not correctly reflected.