### PR TITLE
Fix python-publish job

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build setuptools wheel twine
+          pip install tox
       - name: Build
         run: |
-          python -m build --sdist --wheel
+          tox -e build
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+          pip install build setuptools wheel twine
       - name: Build
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build --sdist --wheel
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
This PR fixes the issue related to the automated package versioning when using `python setup.py` (the fallback version `0.0.0` was used in place of the correct one).